### PR TITLE
Remove mateconf from configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,9 +40,6 @@ fi
 
 AC_SUBST(HTML_DIR)
 
-AC_PATH_PROG(MATECONFTOOL, mateconftool-2)
-AM_MATECONF_SOURCE_2
-
 PKG_CHECK_MODULES(GKSU, [libgksu2 >= 2.0.8, gtk+-2.0 >= 2.4.0])
 
 gtk_doc_min_version=1.0


### PR DESCRIPTION
This patch simply removes the mateconf lines from configure.ac since the caja extension doesn't require them (which should make this extension ready for MATE 1.5).
